### PR TITLE
fix(cli): extract repeated command/format strings into constants

### DIFF
--- a/cmd/schema-lens/main.go
+++ b/cmd/schema-lens/main.go
@@ -15,7 +15,13 @@ import (
 
 var version = "dev"
 
-const formatMarkdown = "markdown"
+const (
+	cmdAnalyze = "analyze"
+	cmdMigrate = "migrate"
+
+	formatJSON     = "json"
+	formatMarkdown = "markdown"
+)
 
 func main() {
 	if err := newRootCmd().Execute(); err != nil {
@@ -46,7 +52,7 @@ func newAnalyzeCmd() *cobra.Command {
 	opts := &analyzeOpts{}
 
 	cmd := &cobra.Command{
-		Use:   "analyze",
+		Use:   cmdAnalyze,
 		Short: "Analyze database schema quality",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.dsn == "" {
@@ -109,7 +115,7 @@ func runAnalyze(ctx context.Context, opts *analyzeOpts) error {
 // renderSchemaOnly outputs the raw schema information without analysis.
 func renderSchemaOnly(schema *connector.SchemaInfo, format string) error {
 	switch format {
-	case "json":
+	case formatJSON:
 		return reporter.FormatJSON(os.Stdout, schemaToReport(schema))
 	case "table", formatMarkdown:
 		printSchemaTable(schema, format)
@@ -139,7 +145,7 @@ func formatReport(report *reporter.Report, format string) error {
 	switch format {
 	case "table":
 		return reporter.FormatTable(os.Stdout, report)
-	case "json":
+	case formatJSON:
 		return reporter.FormatJSON(os.Stdout, report)
 	case formatMarkdown:
 		return reporter.FormatMarkdown(os.Stdout, report)
@@ -158,7 +164,7 @@ func newMigrateCmd() *cobra.Command {
 	opts := &migrateOpts{}
 
 	cmd := &cobra.Command{
-		Use:   "migrate",
+		Use:   cmdMigrate,
 		Short: "Generate migration SQL from schema analysis",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.dsn == "" {

--- a/cmd/schema-lens/main_test.go
+++ b/cmd/schema-lens/main_test.go
@@ -36,7 +36,7 @@ func TestAnalyzeCmd_MissingDSN(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
-	cmd.SetArgs([]string{"analyze"})
+	cmd.SetArgs([]string{cmdAnalyze})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -54,7 +54,7 @@ func TestAnalyzeCmd_InvalidDSN(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
-	cmd.SetArgs([]string{"analyze", "--dsn", "invalid://not-a-real-database"})
+	cmd.SetArgs([]string{cmdAnalyze, "--dsn", "invalid://not-a-real-database"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -104,7 +104,7 @@ func TestAnalyzeCmd_SQLiteInMemory_SuggestMode(t *testing.T) {
 	})
 
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"analyze", "--dsn", dsn, "--suggest"})
+	cmd.SetArgs([]string{cmdAnalyze, "--dsn", dsn, "--suggest"})
 
 	// The output goes to os.Stdout, so we verify that execution succeeds
 	// without error. The formatReport function writes to os.Stdout directly.
@@ -128,7 +128,7 @@ func TestAnalyzeCmd_SQLiteInMemory_WithProfile(t *testing.T) {
 	})
 
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"analyze", "--dsn", dsn, "--suggest", "--profile"})
+	cmd.SetArgs([]string{cmdAnalyze, "--dsn", dsn, "--suggest", "--profile"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("analyze --suggest --profile command failed: %v", err)
@@ -142,7 +142,7 @@ func TestMigrateCmd_MissingDSN(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
-	cmd.SetArgs([]string{"migrate"})
+	cmd.SetArgs([]string{cmdMigrate})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -165,7 +165,7 @@ func TestAnalyzeCmd_SchemaOnlyMode(t *testing.T) {
 
 	// Without --suggest or --profile, the command renders schema-only output.
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"analyze", "--dsn", dsn})
+	cmd.SetArgs([]string{cmdAnalyze, "--dsn", dsn})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("analyze (schema-only) failed: %v", err)
@@ -183,7 +183,7 @@ func TestAnalyzeCmd_JSONFormat(t *testing.T) {
 	})
 
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"analyze", "--dsn", dsn, "--suggest", "--format", "json"})
+	cmd.SetArgs([]string{cmdAnalyze, "--dsn", dsn, "--suggest", "--format", formatJSON})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("analyze --format json failed: %v", err)
@@ -201,7 +201,7 @@ func TestAnalyzeCmd_MarkdownFormat(t *testing.T) {
 	})
 
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"analyze", "--dsn", dsn, "--suggest", "--format", "markdown"})
+	cmd.SetArgs([]string{cmdAnalyze, "--dsn", dsn, "--suggest", "--format", "markdown"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("analyze --format markdown failed: %v", err)
@@ -222,7 +222,7 @@ func TestMigrateCmd_SQLiteInMemory(t *testing.T) {
 	})
 
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"migrate", "--dsn", dsn})
+	cmd.SetArgs([]string{cmdMigrate, "--dsn", dsn})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("migrate command failed: %v", err)
@@ -243,7 +243,7 @@ func TestAnalyzeCmd_InvalidFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
-	cmd.SetArgs([]string{"analyze", "--dsn", dsn, "--suggest", "--format", "xml"})
+	cmd.SetArgs([]string{cmdAnalyze, "--dsn", dsn, "--suggest", "--format", "xml"})
 
 	err := cmd.Execute()
 	if err == nil {

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -71,7 +71,8 @@ func insertBadSchemaData(t *testing.T, conn *connector.SQLiteConnector) {
 	}
 
 	for i := 1; i <= 5; i++ {
-		if _, err := db.ExecContext(ctx,
+		if _, err := db.ExecContext(
+			ctx,
 			`INSERT INTO "order" (id, customer_id, total, region_id) VALUES (?, ?, ?, ?)`,
 			i, (i%5)+1, fmt.Sprintf("$%d.00", i*10), (i%3)+1,
 		); err != nil {
@@ -92,7 +93,8 @@ func insertProductRow(t *testing.T, db *sql.DB, ctx context.Context, i int) {
 	verified := (i + 1) % 2
 	confirmed := i % 2
 
-	if _, err := db.ExecContext(ctx,
+	if _, err := db.ExecContext(
+		ctx,
 		`INSERT INTO products
 			(id, sku, title, description, addr1, addr2, addr3,
 			 phone1, phone2, phone3,
@@ -285,7 +287,8 @@ func TestIntegration_GoodSchema(t *testing.T) {
 
 	db := conn.DB()
 	for i := 1; i <= 10; i++ {
-		if _, err := db.ExecContext(ctx,
+		if _, err := db.ExecContext(
+			ctx,
 			"INSERT INTO users (id, first_name, last_name, email) VALUES (?, ?, ?, ?)",
 			i, fmt.Sprintf("User%d", i), fmt.Sprintf("Last%d", i), fmt.Sprintf("user%d@example.com", i),
 		); err != nil {
@@ -293,7 +296,8 @@ func TestIntegration_GoodSchema(t *testing.T) {
 		}
 	}
 	for i := 1; i <= 20; i++ {
-		if _, err := db.ExecContext(ctx,
+		if _, err := db.ExecContext(
+			ctx,
 			"INSERT INTO orders (id, user_id, total_amount, order_date) VALUES (?, ?, ?, ?)",
 			i, (i%10)+1, float64(i)*10.5, "2026-01-15",
 		); err != nil {


### PR DESCRIPTION
## 背景
CI (`ci.yml`) は `golangci-lint@latest` を未固定でインストールする。現行 v2.12.x の goconst は **test ファイルの文字列出現もカウント**するため、`cmd/schema-lens` の `analyze`(9), `json`(3), `migrate`(3) が閾値超過となり、**全オープン PR (#15, #20, #21) の `check` が失敗**していた（main 既存の潜在赤）。

## 変更
既存の `formatMarkdown` 定数の慣習に倣い `cmdAnalyze` / `cmdMigrate` / `formatJSON` を追加し、main.go と main_test.go の全出現箇所を置換。goconst が指示する正攻法（定数抽出）で解消。**lint 設定は変更していない**（CLAUDE.md の「lint設定の変更禁止」を遵守）。

## 検証
- `golangci-lint run ./...`（v2.12.2, CIと同一）: 0 issues
- `go test ./cmd/...`: ok

## 効果
- #15 (mysql), #20 (checkout), #21 (sqlite) の `check` gate を解除

## 補足（恒久対応の推奨）
`golangci-lint@latest` の未固定はドリフト再発要因。バージョン固定を推奨（本PRのスコープ外）。